### PR TITLE
Better error handling for proxy access mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ enableLink         | **Optional.** Enable/disable graph with a rendered URL to t
 datasource         | **Required.** Type of the Grafana datasource (`influxdb`, `graphite` or `pnp`). Defaults to `influxdb`.
 defaultdashboard   | **Required.** Name of the default dashboard which will be shown for unconfigured graphs. **Important: `panelID` must be set to `1`!** Defaults to `icinga2-default`.
 defaultdashboardstore | **Optional.** Grafana backend (file or database). Defaults to `Database`.
-accessmode         | **Optional.** Controlls if module proxies all graphs or user loads graphs directly. Direct access speeds up page load, needs `auth.anonymous` enabled in Grafana. Defaults to `proxy`.
+accessmode         | **Optional.** Controls whether graphs are fetched with curl (`proxy`) or are embedded (`direct`). Direct access is faster and needs `auth.anonymous` enabled in Grafana. Defaults to `proxy`.
 
 
 Example:

--- a/library/Grafana/Util.php
+++ b/library/Grafana/Util.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Icinga\Module\Grafana;
+
+class Util
+{
+
+    public static function httpStatusCodetoString($code = 0)
+    {
+        $statuscodes = array(
+            '100' => 'Continue',
+            '101' => 'Switching Protocols',
+            '200' => 'OK',
+            '201' => 'Created',
+            '202' => 'Accepted',
+            '203' => 'Non-Authoritative Information',
+            '204' => 'No Content',
+            '205' => 'Reset Content',
+            '206' => 'Partial Content',
+            '300' => 'Multiple Choices',
+            '302' => 'Found',
+            '303' => 'See Other',
+            '304' => 'Not Modified',
+            '305' => 'Use Proxy',
+            '400' => 'Bad Request',
+            '401' => 'Unauthorized',
+            '402' => 'Payment Required',
+            '403' => 'Forbidden',
+            '404' => 'Not Found',
+            '405' => 'Method Not Allowed',
+            '406' => 'Not Acceptable',
+            '407' => 'Proxy Authentication Required',
+            '408' => 'Request Timeout',
+            '409' => 'Conflict',
+            '410' => 'Gone',
+            '411' => 'Length Required',
+            '412' => 'Precondition Failed',
+            '413' => 'Request Entity Too Large',
+            '414' => 'Request-URI Too Long',
+            '415' => 'Unsupported Media Type',
+            '416' => 'Requested Range Not Satisfiable',
+            '417' => 'Expectation Failed',
+            '500' => 'Internal Server Error',
+            '501' => 'Not Implemented',
+            '502' => 'Bad Gateway',
+            '503' => 'Service Unavailable',
+            '504' => 'Gateway Timeout',
+            '505' => 'HTTP Version Not Supported'
+        );
+        
+        $code = (string)$code;
+        
+        if(array_key_exists($code, $statuscodes)) {
+            return $statuscodes[$code];
+        } else {
+            return $code;
+        }
+    }
+}


### PR DESCRIPTION
- use curl_set_opts
- do not initialize $this->auth with an `@` at the end, but pass this directly to curl_opts (bug introduced in 70a61a3b37965aefcfe70d5df8be25ab43aa2deb)
- curl_error($curl_handle) is not a safe error handling when RETURNTRANSFER is set to true (must check for $res === false, http://stackoverflow.com/questions/16452636/php-curl-what-does-curl-exec-return)
- fetch the http status code and return an error
- add Util class with http status code translation to string
- better explanation of `accesscode` in the docs

fixes #31
fixes #32