### PR TITLE
Allows to specify graph properties by hostgroup and hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,22 @@ Service = "MySQL Users", check_command = mysql_health
 At first glance `Name = "MySQL Usage"` must provide a match. Then `MySQL` and last but not least any service
 `check_command` attribute which is set to `mysql_health`.
 
+After the config section named with service or command is found, the module looks for special properties to show graphs based on hostgroup and hostname, example:
+
+[service]
+dashboard = "Servers"
+panelId = "4"
+dashboard.hostgroup.linux-servers = "Linux"
+panelId.hostgroup.linux-servers = "7"
+dashboard.hostgroup.windows-servers = "windows"
+panelId.hostgroup.windows-servers = "6"
+dashboard.hostname.server1 = "dashboard-for-server1"
+panelId.hostgroup.server1 = "2"
+
+First, the panelId "4" and dashboard "Servers" will be used. If the hostgroup matches "linux-servers", panelId "7" and dashboard "Linux" will be used. If the hostgroup matches "windows-servers", panelId "6" and dashboard "windows" will be used. And if the hostname matches "server1", the dashboard "dashboard-for-server1" and panelId "2" will be used. If no matches are found for hostgroup of hostname, the dashboard = "Servers" and panelId="4" will be used.
+
+
+
 ## Thanks
 
 This module borrows a lot from https://github.com/Icinga/icingaweb2-module-generictts & https://github.com/Icinga/icingaweb2-module-pnp.

--- a/library/Grafana/ProvidedHook/Grapher.php
+++ b/library/Grafana/ProvidedHook/Grapher.php
@@ -124,11 +124,11 @@ class Grapher extends GrapherHook
         }
     }
 
-    private function getGraphConf($serviceName, $serviceCommand)
+    private function getGraphConf($serviceName, $serviceCommand, $hostgroups, $hostName)
     {
-
         $graphconfig = Config::module('grafana', 'graphs');
         $this->graphConfig = $graphconfig;
+
         if ($this->graphConfig->hasSection(strtok($serviceName, ' ')) && ($this->graphConfig->hasSection($serviceName) == False)) {
             $serviceName = strtok($serviceName, ' ');
         }
@@ -138,6 +138,7 @@ class Grapher extends GrapherHook
                 return NULL;
             }
         }
+
         $this->dashboard = $this->graphConfig->get($serviceName, 'dashboard', $this->defaultDashboard);
         $this->dashboardstore = $this->graphConfig->get($serviceName, 'dashboardstore', $this->defaultDashboardStore);
         $this->panelId = $this->graphConfig->get($serviceName, 'panelId', '1');
@@ -146,7 +147,29 @@ class Grapher extends GrapherHook
         $this->height = $this->graphConfig->get($serviceName, 'height', $this->height);
         $this->width = $this->graphConfig->get($serviceName, 'width', $this->width);
 
+        foreach($hostgroups as $key => $value) {
+            $this->dashboard=$this->getFilterProperty($serviceName,'dashboard','hostgroup',$key,$this->dashboard);
+            $this->dashboardstore=$this->getFilterProperty($serviceName,'dashboardstore','hostgroup',$key,$this->dashboardstore);
+            $this->panelId=$this->getFilterProperty($serviceName,'panelId','hostgroup',$key,$this->panelId);
+            $this->customVars=$this->getFilterProperty($serviceName,'customVars','hostgroup',$key,$this->customVars);
+            $this->timerange=$this->getFilterProperty($serviceName,'timerange','hostgroup',$key,$this->timerange);
+            $this->height=$this->getFilterProperty($serviceName,'height','hostgroup',$key,$this->height);
+            $this->width=$this->getFilterProperty($serviceName,'width','hostgroup',$key,$this->width);
+        }
+        $this->dashboard=$this->getFilterProperty($serviceName,'dashboard','hostname',$hostName,$this->dashboard);
+        $this->dashboardstore=$this->getFilterProperty($serviceName,'dashboardstore','hostname',$hostName,$this->dashboardstore);
+        $this->panelId=$this->getFilterProperty($serviceName,'panelId','hostname',$hostName,$this->panelId);
+        $this->customVars=$this->getFilterProperty($serviceName,'customVars','hostname',$hostName,$this->customVars);
+        $this->timerange=$this->getFilterProperty($serviceName,'timerange','hostname',$hostName,$this->timerange);
+        $this->height=$this->getFilterProperty($serviceName,'height','hostname',$hostName,$this->height);
+        $this->width=$this->getFilterProperty($serviceName,'width','hostname',$hostName,$this->width);
+
         return $this;
+    }
+
+    private function getFilterProperty($serviceName,$property,$filter,$key,$default) {
+            $property=sprintf("%s.%s.%s",$property,$filter,$key);
+            return $this->graphConfig->get($serviceName,$property,$default);
     }
 
     private function getTimerangeLink($object, $rangeName, $timeRange)
@@ -308,7 +331,7 @@ class Grapher extends GrapherHook
             $hostName = $object->host->getName();
         }
 
-        if($this->getGraphConf($serviceName, $object->check_command) == NULL) {
+        if($this->getGraphConf($serviceName, $object->check_command, $object->hostgroups, $hostName) == NULL) {
             return;
         }
 


### PR DESCRIPTION
Sometimes we have same servicename and check_command for two different
checks (different perfdata, eg. iops for windows and linux hosts using
nrpe). This change adds the possibility to separate graphs my hostgroup,
and hostname.