### PR TITLE
Render html before the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ defaultdashboardstore | **Optional.** Grafana backend (file or database). Defaul
 accessmode         | **Optional.** Controls whether graphs are fetched with curl (`proxy`), are embedded (`direct`) or in iframe ('iframe'. Direct access is faster and needs `auth.anonymous` enabled in Grafana. Defaults to `proxy`.
 timeout            | **Proxy only** **Optional.** Timeout in seconds for proxy mode to fetch images. Defaults to `5`.
 username           | **Proxy non anonymous only** **Required** HTTP Basic Auth user name to access Grafana.
-password           | **Proxy non anonymous only** **Required** HTTP Basic Auth password to access Grafana. Requires the username setting.
+password           | **Recommended** HTTP Basic Auth password to access Grafana, and key for encryption.
+                     The password field data is also used during data encryption even when the http auth is disabled, so type a password even if you use anonymous auth.
 directrefresh      | **Direct Only** **Optional.** Refresh graphs on direct access. Defaults to `no`.
 usepublic          | **Optional** Enable usage of publichost/protocol. Defaults to `no`.
 publichost         | **Optional** Use a diffrent host for the graph links.

--- a/application/forms/Config/GeneralConfigForm.php
+++ b/application/forms/Config/GeneralConfigForm.php
@@ -190,7 +190,8 @@ class GeneralConfigForm extends ConfigForm
                     array(
                         'renderPassword' => true,
                         'label' => $this->translate('Password'),
-                        'description' => $this->translate('The HTTP Basic Auth password used to access Grafana.'),
+                        'description' => $this->translate('HTTP Basic Auth password to access Grafana, and key for encryption. The password field data is also used during data encryption even when the http auth is disabled, so type a password even if you use anonymous auth.'),
+
                         'required' => true
                     )
                 );


### PR DESCRIPTION
With this change, the graph url is generated and returned to the browser as a
base64 string inside the imgsrc. Now the user doesn't have to wait the image
from grafana to view information about service/host, the image is sent
in a separated http connection.

The image is downloaded and sent to browser when init function is called (before
any header or html is sent by Icinga framework).