### PR TITLE
Change variable hostname to be a constant

### DIFF
--- a/dashboards/graphite/icinga2-default.json
+++ b/dashboards/graphite/icinga2-default.json
@@ -165,24 +165,13 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
         "current": {},
-        "datasource": "${DS_ICINGA2-GRAPHITE}",
         "hide": 2,
-        "includeAll": false,
         "label": null,
-        "multi": false,
         "name": "hostname",
         "options": [],
-        "query": "icinga2.*",
-        "refresh": 1,
-        "regex": "",
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "query": "",
+        "type": "constant"
       },
       {
         "allValue": null,

--- a/dashboards/graphite/icinga2-default.json
+++ b/dashboards/graphite/icinga2-default.json
@@ -174,24 +174,13 @@
         "type": "constant"
       },
       {
-        "allValue": null,
         "current": {},
-        "datasource": "${DS_ICINGA2-GRAPHITE}",
         "hide": 2,
-        "includeAll": false,
         "label": null,
-        "multi": false,
         "name": "service",
         "options": [],
-        "query": "icinga2.$hostname.services.*",
-        "refresh": 1,
-        "regex": "",
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "query": "",
+        "type": "constant"
       }
     ]
   },


### PR DESCRIPTION
Hi there,

first of I'd like to say many thanks for this awesome plugin!
I especially love the look and feel of the iFrame implementation (yes, i hacked my icingaweb2 instance in order to set the autorefresh to 5 mins)!
While digging around a bit, i found that the query for the hostname (icinga2.*) returns ALL hosts in the grafana data source, which i found to be potentially dangerous and perhaps even a bit wasteful.
My Icinga2 instance heavily relies on permissions on the hosts / services, so I wanted to avoid leaking the list of all hosts through grafana :)
So i changed the variable hostname to be a constant since it will be specified within the request URL anyways.

Cheers,
Markus