### PR TITLE
Proxy Mode: Show a better error message if PHP CURL is not installed/loaded

### DIFF
--- a/library/Grafana/ProvidedHook/Grapher.php
+++ b/library/Grafana/ProvidedHook/Grapher.php
@@ -200,6 +200,13 @@ class Grapher extends GrapherHook
     {
         $imgClass = $this->shadows ? "grafana-img grafana-img-shadows" : "grafana-img";
         if ($this->accessMode == "proxy") {
+
+            // Test whether curl is loaded
+            if (extension_loaded('curl') === false) {
+                $previewHtml = "<b>CURL extension is missing. Please install CURL for PHP and ensure it is loaded.</b>";
+                return false;
+            }
+
             $pngUrl = sprintf(
                 '%s://%s/render/dashboard-solo/%s/%s?var-hostname=%s&var-service=%s%s&panelId=%s&orgId=%s&width=%s&height=%s&theme=%s&from=now-%s&to=now',
                 $this->protocol,


### PR DESCRIPTION
Right now you'll see a stacktrace and it is hard to determine why curl_init() is not working. It also breaks the layout of the detail view.

### Steps to reproduce

Disable loaded curl extension.

```
[root@icinga2 grafana]# vim /etc/php.d/curl.ini
; Enable curl extension module
;extension=curl.so

[root@icinga2 grafana]# systemctl restart httpd
```

![screen shot 2017-08-11 at 11 48 18](https://user-images.githubusercontent.com/382049/29208603-0249fd8c-7e8b-11e7-862b-3730e51857ee.png)

### Fix

curl is only required for proxy mode and as such the check must happen each time a graph is fetched. If you add the check to init() errors won't be shown in the detail view, but somewhere else.

![screen shot 2017-08-11 at 11 50 20](https://user-images.githubusercontent.com/382049/29208706-6931e744-7e8b-11e7-924b-82a8b6eac25a.png)

