### PR TITLE
Add support for Grafana auth proxy

### DIFF
--- a/application/forms/Config/GeneralConfigForm.php
+++ b/application/forms/Config/GeneralConfigForm.php
@@ -159,6 +159,21 @@ class GeneralConfigForm extends ConfigForm
             )
         );
 
+        $this->addElement(
+	    'select',
+	    'grafana_authanon',
+	    array(
+	        'label' => $this->translate('Anonymous Access'),
+	        'value' => 'yes',
+	        'multiOptions' => array(
+		    'yes' => $this->translate('Yes'),
+		    'no' => $this->translate('No'),
+	        ),
+	        'description' => $this->translate('Anonymous or username/password access to Grafana server.'),
+	        'class' => 'autosubmit'
+	    )
+        );
+
         if (isset($formData['grafana_accessmode']) && $formData['grafana_accessmode'] === 'proxy') {
             $this->addElement(
                 'number',
@@ -169,28 +184,13 @@ class GeneralConfigForm extends ConfigForm
                     'description' => $this->translate('Timeout in seconds for proxy mode to fetch images.')
                 )
             );
-            $this->addElement(
-                'select',
-                'grafana_authanon',
-                array(
-                    'label' => $this->translate('Anonymous Access'),
-                    'value' => 'yes',
-                    'multiOptions' => array(
-                        'yes' => $this->translate('Yes'),
-                        'no' => $this->translate('No'),
-                    ),
-                    'description' => $this->translate('Anonymous or username/password access to Grafana server.'),
-                    'class' => 'autosubmit'
-                )
-            );
             if (isset($formData['grafana_authanon']) && $formData['grafana_authanon'] === 'no' ) {
                 $this->addElement(
                     'text',
                     'grafana_username',
                     array(
                         'label' => $this->translate('Username'),
-                        'description' => $this->translate('The HTTP Basic Auth user name used to access Grafana.'),
-                        'required' => true
+                        'description' => $this->translate('The HTTP Basic Auth user name used to access Grafana.')
                     )
                 );
                 $this->addElement(
@@ -199,8 +199,7 @@ class GeneralConfigForm extends ConfigForm
                     array(
                         'renderPassword' => true,
                         'label' => $this->translate('Password'),
-                        'description' => $this->translate('The HTTP Basic Auth password used to access Grafana.'),
-                        'required' => true
+                        'description' => $this->translate('The HTTP Basic Auth password used to access Grafana.')
                     )
                 );
             }
@@ -256,6 +255,7 @@ class GeneralConfigForm extends ConfigForm
                 )
             );
         }
+
         if (isset($formData['grafana_enableLink']) && ( $formData['grafana_enableLink'] === 'yes') && ( $formData['grafana_accessmode'] != 'iframe' )) {
             $this->addElement(
                 'select',
@@ -272,6 +272,7 @@ class GeneralConfigForm extends ConfigForm
                 )
             );
         }
+
         if (isset($formData['grafana_usepublic']) && ( $formData['grafana_usepublic'] === 'yes' ) && ( $formData['grafana_accessmode'] != 'iframe' )) {
             $this->addElement(
                 'text',
@@ -296,6 +297,45 @@ class GeneralConfigForm extends ConfigForm
                 )
             );
         }
+
+	if (isset($formData['grafana_accessmode']) && isset($formData['grafana_authanon']) && $formData['grafana_authanon'] === 'no') {
+            $this->addElement(
+                'select',
+                'grafana_authproxy',
+                array(
+                    'label' => $this->translate('Auth Proxy'),
+                    'value' => 'no',
+                    'multiOptions' => array(
+                        'yes' => $this->translate('Yes'),
+                        'no' => $this->translate('No'),
+                    ),
+                    'description' => $this->translate('Use Auth Proxy headers for authentication with Grafana.'),
+                    'class' => 'autosubmit'
+                )
+            );
+        }
+
+        if (isset($formData['grafana_accessmode']) && isset($formData['grafana_authproxy']) && $formData['grafana_authproxy'] === 'yes') {
+            $this->addElement(
+                'text',
+                'grafana_authproxyheader',
+                array(
+                    'label' => $this->translate('Auth proxy header'),
+                    'description' => $this->translate('The name of the header to use for Proxy Authentication.'),
+                    'required' => true
+                )
+            );
+            $this->addElement(
+                'text',
+                'grafana_authproxyvalue',
+                array(
+                    'label' => $this->translate('Auth proxy value'),
+                    'description' => $this->translate('The value of the header to user for Proxy Authentication.'),
+                    'required' => true
+                )
+            );
+        }
+
         $this->addElement(
             'checkbox',
             'grafana_debug',

--- a/doc/03-module-configuration.md
+++ b/doc/03-module-configuration.md
@@ -73,6 +73,8 @@ custvardisable = "idontwanttoseeagraph"
 |authanon           | **Ignore** Only used for configuration via web interface.|
 |username           | **Proxy non anonymous only** **Required** HTTP Basic Auth user name to access Grafana.|
 |password           | **Proxy non anonymous only** **Required** HTTP Basic Auth password to access Grafana. Requires the username setting.|
+|authproxyheader    | **Proxy/iFrame non anonymous only** **Required** HTTP Header Authentication to access Grafana.|
+|authproxyvalue     | **Proxy/iFrame non anonymous only** **Required** HTTP Header Value to access Grafana.|
 |directrefresh      | **Direct Only** **Optional.** Refresh graphs on direct access. Defaults to `no`.|
 |usepublic          | **Optional** Enable usage of publichost/protocol. Defaults to `no`.|
 |publichost         | **Optional** Use a diffrent host for the graph links.|
@@ -155,6 +157,14 @@ The username used to authenticate to Grafana server.
 ### password
 Used with 'proxy' mode, non anonymous access only.
 The password used to authenticate to Grafana server.
+
+### authproxyheader
+Used with 'proxy', 'direct' and 'iframe' mode, non anonymous access only.
+The header used to authenticate to Grafana server.
+
+### authproxyvalue
+Used with 'proxy', 'direct' and 'iframe' mode, non anonymous access only.
+The header value used to authenticate to Grafana server.
 
 ### usepublic
 Enables/Disables the usage of a `public` URL to the Grafana server.


### PR DESCRIPTION
Closes: #97 

This pull request adds support for Grafana's auth.proxy header.

The auth.proxy header can not only be used when using proxy mode, but also with direct & iframe mode.

In iframe/direct mode, it adds the headers as a query string to the request.
In the Apache/nginx proxy, you then can rewrite the query string to an additional header.

A small example:
```
The following rewriterule sets the MagicHeader env if the MagicHeader is specified.
And stips the query string then to the backend.
        <IfModule mod_rewrite.c>
                RewriteEngine on
                RewriteCond %{QUERY_STRING} (.*(?:^|&))MagicHeader=ClkdMazdnFEN((?:&|$).*)
                RewriteRule ^ %{REQUEST_URI}?%1%2 [L,PT,E=MagicHeader]
        </IfModule>

If you already have a grafana_sess, you can just go to the backend.
        SetEnvIf Cookie "(^|;\ *)grafana_sess=([^;\ ]+)" GrafanaCookie

Now you allow connections to the Grafana with a password/or if the header is specified/or if the Cookie exists.
        <Location />
                AuthType basic
                AuthName "private"
                AuthUserFile /etc/apache2/.htpasswd
                Require valid-user
                Require env MagicHeader
                Require env GrafanaCookie
                Require local
                Require ip x.x.x.x
        </Location>

Sets the Auth header when the MagicHeader exists.
        RequestHeader set X-MagicHeader icinga2 env=MagicHeader

        ProxyPreserveHost On
        ProxyPass / http://localhost:3000/
        ProxyPassReverse / http://localhost:3000/
</VirtualHost>

```
