### PR TITLE
Graph configuration based on custom variable

### DIFF
--- a/library/Grafana/ProvidedHook/Grapher.php
+++ b/library/Grafana/ProvidedHook/Grapher.php
@@ -159,18 +159,20 @@ class Grapher extends GrapherHook
         }
     }
 
-    private function getGraphConf($serviceName, $serviceCommand)
+    private function getGraphConf($serviceName, $serviceCommand = NULL)
     {
 
         $this->graphConfig = Config::module('grafana', 'graphs');
 
-        if ($this->graphConfig->hasSection(strtok($serviceName, ' ')) && ($this->graphConfig->hasSection($serviceName) == False)) {
-            $serviceName = strtok($serviceName, ' ');
-        }
-        if ($this->graphConfig->hasSection(strtok($serviceName, ' ')) == False && ($this->graphConfig->hasSection($serviceName) == False)) {
-            $serviceName = $serviceCommand;
-            if($this->graphConfig->hasSection($serviceCommand) == False && $this->defaultDashboard == 'none') {
-                return NULL;
+        if ($serviceCommand != NULL) {
+            if ($this->graphConfig->hasSection(strtok($serviceName, ' ')) && ($this->graphConfig->hasSection($serviceName) == False)) {
+                $serviceName = strtok($serviceName, ' ');
+            }
+            if ($this->graphConfig->hasSection(strtok($serviceName, ' ')) == False && ($this->graphConfig->hasSection($serviceName) == False)) {
+                $serviceName = $serviceCommand;
+                if($this->graphConfig->hasSection($serviceCommand) == False && $this->defaultDashboard == 'none') {
+                    return NULL;
+                }
             }
         }
 
@@ -376,8 +378,14 @@ class Grapher extends GrapherHook
             $hostName = $object->host->getName();
         }
 
-        if($this->getGraphConf($serviceName, $object->check_command) == NULL) {
-            return;
+        if (isset($object->customvars['grafana_graph_confname'])) {
+            if($this->getGraphConf($object->customvars['grafana_graph_confname']) == NULL) {
+                return ;
+            }
+        } else {
+            if($this->getGraphConf($serviceName, $object->check_command) == NULL) {
+                return;
+            }
         }
 
         if($this->repeatable == "yes" ) {


### PR DESCRIPTION
Using the custom variable "grafana_graph_confname" you can specify a name of the Grafana Graphs configuration.
This replaces the need for us to have regex based matching as discussed in issue #112 

Do you like the direction of this?
Of course it can still be beautified (e.g. the name of the custom variable could be made configurable, docs are missing)

I've tested it by setting the custom variable in some templates and the accordingly named Grafana Graphs config was used. For other graphs the normal behavior is used (matching based on servicename/check command).