### PR TITLE
Fix disk dashboard so it can be used for disk and disk-windows

### DIFF
--- a/dashboards/influxdb/itl/disk.json
+++ b/dashboards/influxdb/itl/disk.json
@@ -131,7 +131,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "disk",
+              "measurement": "/^$command$/",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",


### PR DESCRIPTION
The disk dashboard works fine on check-command=disk, but its broken when check-command is disk-windows.

Adapted the dashboard so it works fine for both check-commands :smile: 