### PR TITLE
Add default graph option

### DIFF
--- a/application/controllers/ImgController.php
+++ b/application/controllers/ImgController.php
@@ -35,6 +35,7 @@ class ImgController extends MonitoringAwareController
     protected $defaultDashboard        = "icinga2-default";
     protected $defaultDashboardPanelId = "1";
     protected $defaultOrgId            = "1";
+    protected $defaultGraph            = null;
     protected $shadows                 = false;
     protected $defaultDashboardStore   = "db";
     protected $dataSource              = null;
@@ -81,6 +82,7 @@ class ImgController extends MonitoringAwareController
             );
         }
         $this->defaultDashboardPanelId = $this->myConfig->get('defaultdashboardpanelid', $this->defaultDashboardPanelId);
+        $this->defaultGraph = $this->myConfig->get('defaultgraph', $this->defaultGraph);
         $this->defaultOrgId = $this->myConfig->get('defaultorgid', $this->defaultOrgId);
         $this->grafanaTheme = $this->myConfig->get('theme', $this->grafanaTheme);
         $this->defaultDashboardStore = $this->myConfig->get('defaultdashboardstore', $this->defaultDashboardStore);
@@ -252,9 +254,10 @@ class ImgController extends MonitoringAwareController
         }
         if ($graphConfig->hasSection(strtok($serviceName, ' ')) == False && ($graphConfig->hasSection($serviceName) == False)) {
             $serviceName = $serviceCommand;
-            if($graphConfig->hasSection($serviceCommand) == False && $this->defaultDashboard == 'none') {
-                return NULL;
-            }
+            if ($this->graphConfig->hasSection($serviceCommand) == False) {
+                if ($this->defaultDashboard == 'none' && $this->defaultGraph == null) return NULL;
+                if ($this->defaultGraph != null) $serviceName = $this->defaultGraph;
+            } 
         }
 
         $this->dashboard = $graphConfig->get($serviceName, 'dashboard', $this->defaultDashboard);

--- a/application/forms/Config/GeneralConfigForm.php
+++ b/application/forms/Config/GeneralConfigForm.php
@@ -142,6 +142,15 @@ class GeneralConfigForm extends ConfigForm
             )
         );
         $this->addElement(
+            'text',
+            'grafana_defaultgraph',
+            array(
+                'label' => $this->translate('Default graph'),
+                'description' => $this->translate('Name of the grafana graph which should be used when no service matches the graph names.'),
+                'required' => false,
+            )
+        );
+        $this->addElement(
             'number',
             'grafana_defaultorgid',
             array(

--- a/doc/03-module-configuration.md
+++ b/doc/03-module-configuration.md
@@ -71,14 +71,15 @@ ssl_verifyhost = "0"
 |enableLink             | **Optional.** Enable/disable graph with a rendered URL to the Grafana dashboard. Defaults to `yes`.|
 |datasource             | **Required for Grafana 4.x only.** Type of the Grafana datasource (`influxdb`, `graphite` or `pnp`). Defaults to `influxdb`.|
 |defaultdashboard       | **Required.** Name of the default dashboard which will be shown for unconfigured graphs. Set to `none` to hide the module output. Defaults to `icinga2-default`.|
-|defaultdashboarduid    | **Required for Grafana 5** The UID of the default dashbaoard for **Grafana 5**.
-|defaultdashboardpanelid| **Required** ID of the panel used in the default dashboard. Defaults to `1`.
+|defaultdashboarduid    | **Required for Grafana 5** The UID of the default dashbaoard for **Grafana 5**.|
+|defaultdashboardpanelid| **Required** ID of the panel used in the default dashboard. Defaults to `1`.|
+|defaultgraph           | **Optional** Name of the grafana graph which should be used when no service matches the graph names.|
 |shadows                | **Optional.** Show shadows around the graphs. ** Defaults to `false`.|
-|defaultorgid           | **Required.** Number of the default organization id where dashboards are located. Defaults to `1`.
+|defaultorgid           | **Required.** Number of the default organization id where dashboards are located. Defaults to `1`.|
 |defaultdashboardstore  | **Optional.** Grafana backend (file or database). Defaults to `Database`.|
 |accessmode             | **Optional.** Controls whether graphs are fetched with curl (`proxy` & `indirectproxy`), are embedded (`direct`) or in iframe ('iframe'). Direct access & iframe needs `auth.anonymous` enabled in Grafana. Defaults to `proxy`.|
 |timeout                | **Proxy only** **Optional.** Timeout in seconds for proxy mode to fetch images. Defaults to `5`.|
-|authentication         | **Proxy only** Authentication type used to acccess Grafana. Can be set to `anon`,`token` or `basic`. Defaults to `anon`.
+|authentication         | **Proxy only** Authentication type used to acccess Grafana. Can be set to `anon`,`token` or `basic`. Defaults to `anon`.|
 |username               | **Proxy with basic only** **Required** HTTP Basic Auth user name to access Grafana.|
 |password               | **Proxy with basic only** **Required** HTTP Basic Auth password to access Grafana. Requires the username setting.|
 |apitoken               | **Proxy with token only** **Required** API token used to access Grafana.|
@@ -146,6 +147,9 @@ For example the URL is 'https://192.168.178.52:3000/d/FxAre-ekz/icinga2-default?
 ### defaultdashboardpanelid
 The id of the panel used in the defaul dashboard. Defaults to `1`.
 This is needed if you use **Grafana 5** and imported or created a new default dashboard, because the first useable panel id is now `2`.
+
+### defaultgraph
+The name of the graph in the grafana graphs list.
 
 ### defaultdashboardstore
 The dashboard store, `database`or `file`, that is used by Grafana server. Defaults to `database`

--- a/library/Grafana/ProvidedHook/Grapher.php
+++ b/library/Grafana/ProvidedHook/Grapher.php
@@ -36,6 +36,7 @@ class Grapher extends GrapherHook
     protected $enableLink              = true;
     protected $defaultDashboard        = "icinga2-default";
     protected $defaultDashboardPanelId = "1";
+    protected $defaultGraph            = null;
     protected $defaultOrgId            = "1";
     protected $shadows                 = false;
     protected $defaultDashboardStore   = "db";
@@ -93,6 +94,7 @@ class Grapher extends GrapherHook
             );
         }
         $this->defaultDashboardPanelId = $this->config->get('defaultdashboardpanelid', $this->defaultDashboardPanelId);
+        $this->defaultGraph = $this->config->get('defaultgraph', $this->defaultGraph);
         $this->defaultOrgId = $this->config->get('defaultorgid', $this->defaultOrgId);
         $this->grafanaTheme = $this->config->get('theme', $this->grafanaTheme);
         $this->defaultDashboardStore = $this->config->get('defaultdashboardstore', $this->defaultDashboardStore);
@@ -175,9 +177,10 @@ class Grapher extends GrapherHook
         }
         if ($this->graphConfig->hasSection(strtok($serviceName, ' ')) == False && ($this->graphConfig->hasSection($serviceName) == False)) {
             $serviceName = $serviceCommand;
-            if($this->graphConfig->hasSection($serviceCommand) == False && $this->defaultDashboard == 'none') {
-                return NULL;
-            }
+            if ($this->graphConfig->hasSection($serviceCommand) == False) {
+                if ($this->defaultDashboard == 'none' && $this->defaultGraph == null) return NULL;
+                if ($this->defaultGraph != null) $serviceName = $this->defaultGraph;
+            } 
         }
 
         $this->dashboard = $this->getGraphConfigOption($serviceName, 'dashboard', $this->defaultDashboard);


### PR DESCRIPTION
I need a custom var in all my graphs, but I don't want to configure a graph for each service. 'Config customvar' doesn't behave like default, so I added an option to configure one graph as default. When the old rules don't find any matching graph, the default graph will be taken.

ToDo:

- default graph option should be a drop-down list
- (maybe) remove all options that can be configured in graphs from the global config.