### PR TITLE
Move permission test to the HostActions Hook

### DIFF
--- a/library/Grafana/ProvidedHook/Monitoring/HostActions.php
+++ b/library/Grafana/ProvidedHook/Monitoring/HostActions.php
@@ -7,6 +7,7 @@
  */
 namespace Icinga\Module\Grafana\ProvidedHook\Monitoring;
 
+use Icinga\Authentication\Auth;
 use Icinga\Module\Monitoring\Hook\HostActionsHook;
 use Icinga\Module\Monitoring\Object\Host;
 use Icinga\Web\Navigation\Navigation;
@@ -22,6 +23,10 @@ class HostActions extends HostActionsHook
 
     public function getActionsForHost(Host $host)
     {
+        if (! Auth::getInstance()->hasPermission('grafana/showall')) {
+            return [];
+        }
+
         $config = Config::module('grafana')->getSection('grafana');
         $timerange = $config->get('timerangeAll', $this->defaultTimerange);
         $nav = new Navigation();

--- a/run.php
+++ b/run.php
@@ -1,9 +1,4 @@
 <?php
-use Icinga\Authentication\Auth;
-$auth = Auth::getInstance();
 
 $this->provideHook('grapher');
-
-if ($auth->hasPermission('grafana/showall')) {
-    $this->provideHook('monitoring/HostActions');
-}
+$this->provideHook('monitoring/HostActions');


### PR DESCRIPTION
The Auth singleton is not fully initialized when loading modules because
modules may provide custom user backends which in turn requires the
modules to be loaded.

Checking for permissions in run.php may fail if the user is
authenticated via Web 2's external backend or any custom user backend.

Plus, run.php files should be thin with less logic as possible because
they're evaluated on every single request.

Of course Web 2 should provide something to only register hooks if
specific permissions apply like it's the case for menu entries but
this change has not been introduced yet.

Rationale: Icinga/icingaweb2#3470 and Icinga/icingaweb2#3500

refs Icinga/icingaweb2#3470