### PR TITLE
Fix distorted graphs in service/host views

### DIFF
--- a/library/Grafana/ProvidedHook/Grapher.php
+++ b/library/Grafana/ProvidedHook/Grapher.php
@@ -349,20 +349,18 @@ class Grapher extends GrapherHook
                     'cachetime' => $this->cacheTime
                 ));
             }
-            $imghtml = '<img src="%s%s" alt="%s" width="%spx" height="%spx" class="' . $imgClass . '" style="min-height: %spx;"/>';
+            $imghtml = '<img src="%s%s" alt="%s" width="%spx" height="%spx" class="' . $imgClass . '"/>';
             $previewHtml = sprintf(
                 $imghtml,
                 $this->getView()->serverUrl(),
                 $this->pngUrl,
                 $serviceName,
                 $this->width,
-                $this->height,
                 $this->height
-
             );
         } elseif ($this->accessMode == "direct") {
             if ($this->grafanaVersion == "1") {
-                $imghtml = '<img src="%s://%s/render/d-solo/%s/%s?var-hostname=%s&var-service=%s&var-command=%s%s&panelId=%s&orgId=%s&width=%s&height=%s&theme=%s&from=%s&to=%s&trickrefresh=%s" alt="%s" width="%spx" height="%spx" class="' . $imgClass . '" style="min-height: %spx;"/>';
+                $imghtml = '<img src="%s://%s/render/d-solo/%s/%s?var-hostname=%s&var-service=%s&var-command=%s%s&panelId=%s&orgId=%s&width=%s&height=%s&theme=%s&from=%s&to=%s&trickrefresh=%s" alt="%s" width="%spx" height="%spx" class="' . $imgClass . '"/>';
                 $previewHtml = sprintf(
                     $imghtml,
                     $this->protocol,
@@ -383,11 +381,10 @@ class Grapher extends GrapherHook
                     $this->refresh,
                     rawurlencode($serviceName),
                     $this->width,
-                    $this->height,
                     $this->height
                 );
             } else {
-                $imghtml = '<img src="%s://%s/render/dashboard-solo/%s/%s?var-hostname=%s&var-service=%s&var-command=%s%s&panelId=%s&orgId=%s&width=%s&height=%s&theme=%s&from=%s&to=%s&trickrefresh=%s" alt="%s" width="%spx" height="%spx" class="' . $imgClass . '" style="min-height: %spx;"/>';
+                $imghtml = '<img src="%s://%s/render/dashboard-solo/%s/%s?var-hostname=%s&var-service=%s&var-command=%s%s&panelId=%s&orgId=%s&width=%s&height=%s&theme=%s&from=%s&to=%s&trickrefresh=%s" alt="%s" width="%spx" height="%spx" class="' . $imgClass . '"/>';
                 $previewHtml = sprintf(
                     $imghtml,
                     $this->protocol,
@@ -408,7 +405,6 @@ class Grapher extends GrapherHook
                     $this->refresh,
                     rawurlencode($serviceName),
                     $this->width,
-                    $this->height,
                     $this->height
                 );
             }


### PR DESCRIPTION
If the device/view width is smaller than the defined width of the graph it gets distorted:
![distorted](https://user-images.githubusercontent.com/915514/47388898-a953ec00-d713-11e8-92a1-057b85dc2df7.png)

The cause of this is `style="min-height: ..."` (in `library/Grafana/ProvidedHook/Grapher.php`) which forces the image to retain the original height even when it's width automatically gets scaled down (due to `max-width: 100%` in `public/css/modules.less`).

With my commit it looks as I think it is supposed to be:
![okay](https://user-images.githubusercontent.com/915514/47389147-52024b80-d714-11e8-8a2b-f1e953ba0891.png)