### PR TITLE
Bugfix "link to grafana broken"

### DIFF
--- a/library/Grafana/ProvidedHook/Grapher.php
+++ b/library/Grafana/ProvidedHook/Grapher.php
@@ -467,6 +467,16 @@ class Grapher extends GrapherHook
             return false;
         }
     }
+    
+    // see: https://icinga.com/docs/icinga2/latest/doc/14-features/#graphite-schema
+    private function escapeVarToGraphiteSchema($variable)
+    {
+        $variable = str_replace(' ', '_', $variable);
+        $variable = str_replace('.', '_', $variable);
+        $variable = str_replace('\\', '_', $variable);
+        $variable = str_replace('/', '_', $variable);
+        return $variable;
+    }
 
     public function getPreviewHtml(MonitoredObject $object, $report = false)
     {
@@ -576,9 +586,9 @@ class Grapher extends GrapherHook
                         $this->publicHost,
                         $this->dashboarduid,
                         $this->dashboard,
-                        rawurlencode($hostName),
-                        rawurlencode($serviceName),
-                        rawurlencode($this->object->check_command),
+                        rawurlencode($this->escapeVarToGraphiteSchema($hostName)),
+                        rawurlencode($this->escapeVarToGraphiteSchema($serviceName)),
+                        rawurlencode($this->escapeVarToGraphiteSchema($this->object->check_command)),
                         $this->customVars,
                         urlencode($this->timerange),
                         urlencode($this->timerangeto),
@@ -595,9 +605,9 @@ class Grapher extends GrapherHook
                         $this->publicHost,
                         $this->dashboardstore,
                         $this->dashboard,
-                        rawurlencode($hostName),
-                        rawurlencode($serviceName),
-                        rawurlencode($this->object->check_command),
+                        rawurlencode($this->escapeVarToGraphiteSchema($hostName)),
+                        rawurlencode($this->escapeVarToGraphiteSchema($serviceName)),
+                        rawurlencode($this->escapeVarToGraphiteSchema($this->object->check_command)),
                         $this->customVars,
                         urlencode($this->timerange),
                         urlencode($this->timerangeto),


### PR DESCRIPTION
Hi,

I found an bug in redirecting to Grafana when clicking on a graph.

**Situation:**
If the option "activate link" is activated, you can click on the performance graph. Unfortunately, the variables (hostname, service, check_command) are not escaped.
I use the graphite plugin from Icinga2 for data transfer to Grafana. Icinga documentation:
`https://icinga.com/docs/icinga2/latest/doc/14-features/#graphite-schema`. -> Special characters are escaped in the labels.
My hostnames are FQDN, for example "example.com". This host name becomes "example_com" through the Graphite writer. This change will not be considered by this plugin.

**Solution:**
I've added a new **#escapeVarToGraphiteSchema()** function that does exactly that escaping according to Icinga-Doc. Since then, the forwarding to Grafana works for me.

**Test:**
Tested on Icinga2 -> Graphite (Backend) -> Grafana -> IcingaWeb2-Module-Grafana.
I do not know if there is a bug with other backends, InfluxDB or PNP. At this point in the code but also not previously distinguished between the backends.

PS: php is not my main language. So if there is a better solution, please correct me.