### PR TITLE
Allow spaces in objectnames for DashboardController

### DIFF
--- a/application/controllers/DashboardController.php
+++ b/application/controllers/DashboardController.php
@@ -23,8 +23,8 @@ class DashboardController extends Controller
             'url' => $this->getRequest()->getUrl()
         ));
 
-        $hostname = $this->params->getRequired('host');
-        $servicename = $this->params->get('service');
+        $hostname = str_replace('+', ' ', $this->params->getRequired('host'));
+        $servicename = str_replace('+', ' ', $this->params->get('service'));
 
         if ($servicename != null) {
             $object = new Service($this->backend, $hostname, $servicename);


### PR DESCRIPTION
Hi there,

when I have a host or service object using a space in its name, its graph cannot be embedded in a dashboard, since its spaces are being replaced with + characters.

This PR replaces the '+' characters with ' ' so that the filters will successfully match again.

Regards,
Markus