### PR TITLE
Add compatibility to default icinga2 graphite writer.

### DIFF
--- a/application/controllers/ImgController.php
+++ b/application/controllers/ImgController.php
@@ -20,6 +20,7 @@ class ImgController extends MonitoringAwareController
 {
     protected $host;
     protected $service;
+    protected $graphType               = 'services';
     protected $timerange;
     protected $myConfig;
     protected $myAuth;
@@ -34,6 +35,8 @@ class ImgController extends MonitoringAwareController
     protected $height                  = 280;
     protected $defaultDashboard        = "icinga2-default";
     protected $defaultDashboardPanelId = "1";
+    protected $defaultDashboardPanelIdHost = "2";
+    protected $defaultDashboardPanelIdServices = "1";
     protected $defaultOrgId            = "1";
     protected $shadows                 = false;
     protected $defaultDashboardStore   = "db";
@@ -50,7 +53,6 @@ class ImgController extends MonitoringAwareController
 
     public function init()
     {
-
         /* we need at least a host name */
         if (is_null($this->getParam('host')))
         {
@@ -90,6 +92,8 @@ class ImgController extends MonitoringAwareController
             );
         }
         $this->defaultDashboardPanelId = $this->myConfig->get('defaultdashboardpanelid', $this->defaultDashboardPanelId);
+        $this->defaultDashboardPanelIdHost = $this->myConfig->get('defaultdashboardpanelid_host', $this->defaultDashboardPanelIdHost);
+        $this->defaultDashboardPanelIdServices = $this->myConfig->get('defaultdashboardpanelid_services', $this->defaultDashboardPanelIdServices);
         $this->defaultOrgId = $this->myConfig->get('defaultorgid', $this->defaultOrgId);
         $this->grafanaTheme = $this->myConfig->get('theme', $this->grafanaTheme);
         $this->defaultDashboardStore = $this->myConfig->get('defaultdashboardstore', $this->defaultDashboardStore);
@@ -127,7 +131,6 @@ class ImgController extends MonitoringAwareController
         /**
          * Username & Password or token
          */
-
         $this->apiToken = $this->myConfig->get('apitoken', $this->apiToken);
         $this->authentication = $this->myConfig->get('authentication');
         if ($this->apiToken == null && $this->authentication == "token") {
@@ -147,7 +150,6 @@ class ImgController extends MonitoringAwareController
                 $this->myAuth = "";
             }
         }
-
     }
 
     public function indexAction()
@@ -202,7 +204,7 @@ class ImgController extends MonitoringAwareController
         }
 
         $imageHtml = "";
-        $res = $this->getMyimageHtml($serviceName, $hostName, $imageHtml);
+        $res = $this->getMyImageHtml($serviceName, $hostName, $imageHtml);
         header('Pragma: public');
         if($this->refresh == "yes") {
             header('Pragma: public');
@@ -316,12 +318,13 @@ class ImgController extends MonitoringAwareController
 
         if ($this->grafanaVersion == "1") {
             $this->pngUrl = sprintf(
-                '%s://%s/render/d-solo/%s/%s?var-hostname=%s&var-service=%s&var-command=%s%s&panelId=%s&orgId=%s&width=%s&height=%s&theme=%s&from=%s&to=%s',
+                '%s://%s/render/d-solo/%s/%s?var-hostname=%s&var-type=%s&var-service=%s&var-command=%s%s&panelId=%s&orgId=%s&width=%s&height=%s&theme=%s&from=%s&to=%s',
                 $this->protocol,
                 $this->grafanaHost,
                 $this->dashboarduid,
                 $this->dashboard,
                 rawurlencode($hostName),
+                rawurlencode($graphType),
                 rawurlencode($serviceName),
                 rawurlencode($this->object->check_command),
                 $this->customVars,
@@ -334,14 +337,14 @@ class ImgController extends MonitoringAwareController
                 urlencode($this->timerangeto)
             );
         } else {
-
             $this->pngUrl = sprintf(
-                '%s://%s/render/dashboard-solo/%s/%s?var-hostname=%s&var-service=%s&var-command=%s%s&panelId=%s&orgId=%s&width=%s&height=%s&theme=%s&from=%s&to=%s',
+                '%s://%s/render/dashboard-solo/%s/%s?var-hostname=%s&var-type=%s&var-service=%s&var-command=%s%s&panelId=%s&orgId=%s&width=%s&height=%s&theme=%s&from=%s&to=%s',
                 $this->protocol,
                 $this->grafanaHost,
                 $this->dashboardstore,
                 $this->dashboard,
                 rawurlencode($hostName),
+                rawurlencode($graphType),
                 rawurlencode($serviceName),
                 rawurlencode($this->object->check_command),
                 $this->customVars,

--- a/application/controllers/ImgController.php
+++ b/application/controllers/ImgController.php
@@ -58,13 +58,17 @@ class ImgController extends MonitoringAwareController
         }
 
         /* save timerange from params for later use */
-        $this->timerange = $this->hasParam('timerange') ? urldecode($this->getParam('timerange')) : null;
+        $this->timerange = $this->hasParam('timerange')
+            ? urldecode($this->getParam('timerange'))
+            : null;
         if($this->hasParam('timerangeto')) {
             $this->timerangeto = urldecode($this->getParam('timerangeto'));
         } else {
             $this->timerangeto = strpos($this->timerange, '/') ? 'now-' . $this->timerange : "now";
         }
-        $this->cacheTime = $this->hasParam('cachetime') ? $this->getParam('cachetime') : 300;
+        $this->cacheTime = $this->hasParam('cachetime')
+            ? $this->getParam('cachetime')
+            : 300;
 
         /* load global configuration */
         $this->myConfig = Config::module('grafana')->getSection('grafana');
@@ -79,7 +83,8 @@ class ImgController extends MonitoringAwareController
 
         $this->defaultDashboard = $this->myConfig->get('defaultdashboard', $this->defaultDashboard);
         $this->defaultdashboarduid = $this->myConfig->get('defaultdashboarduid', NULL);
-        if ($this->grafanaVersion == "1" && is_null($this->defaultdashboarduid)) {
+        if ($this->grafanaVersion == "1"
+            && is_null($this->defaultdashboarduid)) {
             throw new ConfigurationError(
                 'Usage of Grafana 5 is configured but no UID for default dashboard found!'
             );
@@ -160,7 +165,8 @@ class ImgController extends MonitoringAwareController
             $hostName = $this->object->getName();
         }
 
-        if (array_key_exists($this->custvarconfig, $this->object->customvars) && ! empty($this->object->customvars[$this->custvarconfig])) {
+        if (array_key_exists($this->custvarconfig, $this->object->customvars)
+                && ! empty($this->object->customvars[$this->custvarconfig])) {
             $this->setGraphConf($this->object->customvars[$this->custvarconfig]);
         } else {
             $this->setGraphConf($serviceName, $this->object->check_command);
@@ -207,8 +213,7 @@ class ImgController extends MonitoringAwareController
             header('Cache-Control: max-age='. (365*86440));
         }
         header("Content-type: image/png");
-        if (! $res)
-        {
+        if (! $res) {
             // set expire to now and max age to 1 minute
             header("Expires: ".gmdate("D, d M Y H:i:s", time())." GMT");
             header('Cache-Control: max-age='. 120);
@@ -266,31 +271,41 @@ class ImgController extends MonitoringAwareController
     {
         $graphConfig = Config::module('grafana', 'graphs');
 
-        if ($graphConfig->hasSection(strtok($serviceName, ' ')) && ($graphConfig->hasSection($serviceName) == False)) {
+        if ($graphConfig->hasSection(strtok($serviceName, ' '))
+            && ($graphConfig->hasSection($serviceName) == False)) {
             $serviceName = strtok($serviceName, ' ');
         }
-        if ($graphConfig->hasSection(strtok($serviceName, ' ')) == False && ($graphConfig->hasSection($serviceName) == False)) {
+        if ($graphConfig->hasSection(strtok($serviceName, ' ')) == False
+            && ($graphConfig->hasSection($serviceName) == False)) {
             $serviceName = $serviceCommand;
-            if($graphConfig->hasSection($serviceCommand) == False && $this->defaultDashboard == 'none') {
+            if($graphConfig->hasSection($serviceCommand) == False
+                && $this->defaultDashboard == 'none') {
                 return NULL;
             }
         }
 
         $this->dashboard = $graphConfig->get($serviceName, 'dashboard', $this->defaultDashboard);
-        if ($this->grafanaVersion == "1")
-        {
+        if ($this->grafanaVersion == "1") {
             $this->dashboarduid = $graphConfig->get($serviceName, 'dashboarduid', $this->defaultdashboarduid);
         } else {
             $this->dashboardstore = $graphConfig->get($serviceName, 'dashboardstore', $this->defaultDashboardStore);
         }
-        $this->panelId = $this->hasParam('panelid') ? $this->getParam('panelid') : $graphConfig->get($serviceName, 'panelId', $this->defaultDashboardPanelId);
+        $this->panelId = $this->hasParam('panelid')
+            ? $this->getParam('panelid')
+            : $graphConfig->get($serviceName, 'panelId', $this->defaultDashboardPanelId);
+        $this->panelIdHost = $this->hasParam('panelidhost')
+            ? $this->getParam('panelidhost')
+            : $graphConfig->get($serviceName, 'panelIdHost', $this->defaultDashboardPanelIdHost);
+        $this->panelIdServices = $this->hasParam('panelidservices')
+            ? $this->getParam('panelidservices')
+            : $graphConfig->get($serviceName, 'panelIdServices', $this->defaultDashboardPanelIdServices);
         $this->orgId = $graphConfig->get($serviceName, 'orgId', $this->defaultOrgId);
         $this->customVars = $graphConfig->get($serviceName, 'customVars', '');
         $this->height = $graphConfig->get($serviceName, 'height', $this->height);
         $this->width = $graphConfig->get($serviceName, 'width', $this->width);
-
     }
-    private function getMyimageHtml($serviceName, $hostName, &$imageHtml)
+
+    private function getMyImageHtml($serviceName, $hostName, &$imageHtml, $graphType )
     {
         $imgClass = $this->shadows ? "grafana-img grafana-img-shadows" : "grafana-img";
         // Test whether curl is loaded
@@ -298,8 +313,8 @@ class ImgController extends MonitoringAwareController
             $imageHtml = $this->translate('CURL extension is missing. Please install CURL for PHP and ensure it is loaded.');
             return false;
         }
-        if ($this->grafanaVersion == "1")
-        {
+
+        if ($this->grafanaVersion == "1") {
             $this->pngUrl = sprintf(
                 '%s://%s/render/d-solo/%s/%s?var-hostname=%s&var-service=%s&var-command=%s%s&panelId=%s&orgId=%s&width=%s&height=%s&theme=%s&from=%s&to=%s',
                 $this->protocol,
@@ -353,7 +368,9 @@ class ImgController extends MonitoringAwareController
         );
 
         if ($this->authentication == "token") {
-            $curl_opts[CURLOPT_HTTPHEADER] = array('Content-Type: application/json' , "Authorization: Bearer ". $this->apiToken);
+            $curl_opts[CURLOPT_HTTPHEADER] = array(
+                'Content-Type: application/json',
+                "Authorization: Bearer ". $this->apiToken);
         } else {
             $curl_opts[CURLOPT_USERPWD] = "$this->myAuth";
         }

--- a/application/controllers/ImgController.php
+++ b/application/controllers/ImgController.php
@@ -175,7 +175,7 @@ class ImgController extends MonitoringAwareController
                 $this->customVars = str_replace($search, $replace, $this->customVars);
             }
 
-            // urlencodee values
+            // urlencode values
             $customVars = "";
             foreach (preg_split('/\&/', $this->customVars, -1, PREG_SPLIT_NO_EMPTY) as $param) {
                 $arr = explode("=", $param);
@@ -366,7 +366,7 @@ class ImgController extends MonitoringAwareController
         if ($res === false) {
             $imageHtml .=$this->translate('Cannot fetch graph with curl') .': '. curl_error($curl_handle). '.';
 
-            //provide a hint for 'Failed to connect to ...: Permission denied'
+            // provide a hint for 'Failed to connect to ...: Permission denied'
             if (curl_errno($curl_handle) == 7) {
                 $imageHtml .= $this->translate(' Check SELinux/Firewall.');
             }

--- a/application/forms/Config/GeneralConfigForm.php
+++ b/application/forms/Config/GeneralConfigForm.php
@@ -120,7 +120,8 @@ class GeneralConfigForm extends ConfigForm
                 'description' => $this->translate('Name of the default dashboard.'),
             )
         );
-        if (isset($formData['grafana_version']) && $formData['grafana_version'] === '1' ) {
+        if (isset($formData['grafana_version'])
+            && $formData['grafana_version'] === '1' ) {
             $this->addElement(
                 'text',
                 'grafana_defaultdashboarduid',
@@ -159,7 +160,8 @@ class GeneralConfigForm extends ConfigForm
                 'description' => $this->translate('Show shadows around the graph.'),
             )
         );
-        if (! isset($formData['grafana_version']) || $formData['grafana_version'] === '0' ) {
+        if (! isset($formData['grafana_version'])
+            || $formData['grafana_version'] === '0' ) {
             $this->addElement(
                 'select',
                 'grafana_defaultdashboardstore',
@@ -216,7 +218,9 @@ class GeneralConfigForm extends ConfigForm
             )
         );
 
-        if (isset($formData['grafana_accessmode']) && ($formData['grafana_accessmode'] === 'proxy' || $formData['grafana_accessmode'] === 'indirectproxy')) {
+        if (isset($formData['grafana_accessmode'])
+            && ($formData['grafana_accessmode'] === 'proxy'
+            || $formData['grafana_accessmode'] === 'indirectproxy')) {
             $this->addElement(
                 'number',
                 'grafana_proxytimeout',
@@ -241,7 +245,8 @@ class GeneralConfigForm extends ConfigForm
                     'class' => 'autosubmit'
                 )
             );
-            if (isset($formData['grafana_authentication']) && $formData['grafana_authentication'] === 'basic' ) {
+            if (isset($formData['grafana_authentication'])
+                && $formData['grafana_authentication'] === 'basic' ) {
                     $this->addElement(
                         'text',
                         'grafana_username',
@@ -261,7 +266,8 @@ class GeneralConfigForm extends ConfigForm
                             'required' => true
                         )
                     );
-            } elseif (isset($formData['grafana_authentication']) && $formData['grafana_authentication'] === 'token' ) {
+            } elseif (isset($formData['grafana_authentication'])
+                && $formData['grafana_authentication'] === 'token' ) {
                 $this->addElement(
                     'text',
                     'grafana_apitoken',
@@ -273,8 +279,8 @@ class GeneralConfigForm extends ConfigForm
                 );
             }
         }
-
-        if (isset($formData['grafana_accessmode']) && $formData['grafana_accessmode'] === 'direct') {
+        if (isset($formData['grafana_accessmode'])
+            && $formData['grafana_accessmode'] === 'direct') {
             $this->addElement(
                 'select',
                 'grafana_directrefresh',
@@ -289,7 +295,8 @@ class GeneralConfigForm extends ConfigForm
                 )
             );
         }
-        if (isset($formData['grafana_accessmode']) && $formData['grafana_accessmode'] === 'indirectproxy') {
+        if (isset($formData['grafana_accessmode'])
+            && $formData['grafana_accessmode'] === 'indirectproxy') {
             $this->addElement(
                 'select',
                 'grafana_indirectproxyrefresh',
@@ -339,7 +346,9 @@ class GeneralConfigForm extends ConfigForm
                 )
             );
         }
-        if (isset($formData['grafana_enableLink']) && ( $formData['grafana_enableLink'] === 'yes') && ( $formData['grafana_accessmode'] != 'iframe' )) {
+        if (isset($formData['grafana_enableLink'])
+            && ( $formData['grafana_enableLink'] === 'yes')
+            && ( $formData['grafana_accessmode'] != 'iframe' )) {
             $this->addElement(
                 'select',
                 'grafana_usepublic',
@@ -355,7 +364,9 @@ class GeneralConfigForm extends ConfigForm
                 )
             );
         }
-        if (isset($formData['grafana_usepublic']) && ( $formData['grafana_usepublic'] === 'yes' ) && ( $formData['grafana_accessmode'] != 'iframe' )) {
+        if (isset($formData['grafana_usepublic'])
+            && ( $formData['grafana_usepublic'] === 'yes' )
+            && ( $formData['grafana_accessmode'] != 'iframe' )) {
             $this->addElement(
                 'text',
                 'grafana_publichost',

--- a/application/forms/Config/GeneralConfigForm.php
+++ b/application/forms/Config/GeneralConfigForm.php
@@ -311,17 +311,8 @@ class GeneralConfigForm extends ConfigForm
                 )
             );
         }
-
-        if (isset($formData['grafana_accessmode']) && ( $formData['grafana_accessmode'] != 'iframe' )) {
-            $this->addElement(
-                'number',
-                'grafana_height',
-                array(
-                    'value' => '280',
-                    'label' => $this->translate('Graph height'),
-                    'description' => $this->translate('The default graph height in pixels.')
-                )
-            );
+        if (isset($formData['grafana_accessmode'])
+            && ( $formData['grafana_accessmode'] != 'iframe' )) {
             $this->addElement(
                 'number',
                 'grafana_width',
@@ -329,6 +320,15 @@ class GeneralConfigForm extends ConfigForm
                     'value' => '640',
                     'label' => $this->translate('Graph width'),
                     'description' => $this->translate('The default graph width in pixels.')
+                )
+            );
+            $this->addElement(
+                'number',
+                'grafana_height',
+                array(
+                    'value' => '280',
+                    'label' => $this->translate('Graph height'),
+                    'description' => $this->translate('The default graph height in pixels.')
                 )
             );
             $this->addElement(

--- a/application/forms/Config/GeneralConfigForm.php
+++ b/application/forms/Config/GeneralConfigForm.php
@@ -132,16 +132,40 @@ class GeneralConfigForm extends ConfigForm
                 )
             );
         }
-        $this->addElement(
-            'number',
-            'grafana_defaultdashboardpanelid',
-            array(
-                'value' => '1',
-                'label' => $this->translate('Default panel id'),
-                'description' => $this->translate('Id of the panel used in the default dashboard.'),
-                'required' => true,
-            )
-        );
+        if (isset($formData['grafana_datasource'])
+            && $formData['grafana_datasource'] === 'graphite' ) {
+            $this->addElement(
+                'number',
+                'grafana_defaultdashboardpanelid_host',
+                array(
+                    'value' => '2',
+                    'label' => $this->translate('Default host panel id '),
+                    'description' => $this->translate('Id of the panel used in the default dashboard for displaying a graph attached to a host.'),
+                    'required' => true,
+                )
+            );
+            $this->addElement(
+                'number',
+                'grafana_defaultdashboardpanelid_services',
+                array(
+                    'value' => '1',
+                    'label' => $this->translate('Default services panel id '),
+                    'description' => $this->translate('Id of the panel used in the default dashboard for displaying a graph attached to services.'),
+                    'required' => true,
+                )
+            );
+        } else {
+            $this->addElement(
+                'number',
+                'grafana_defaultdashboardpanelid',
+                array(
+                    'value' => '1',
+                    'label' => $this->translate('Default panel id'),
+                    'description' => $this->translate('Id of the panel used in the default dashboard.'),
+                    'required' => true,
+                )
+            );
+        }
         $this->addElement(
             'number',
             'grafana_defaultorgid',
@@ -201,6 +225,24 @@ class GeneralConfigForm extends ConfigForm
                 'description' => $this->translate('Grafana Datasource Type.')
             )
         );
+        if (isset($formData['grafana_datasource'])
+            && $formData['grafana_datasource'] === 'graphite' ) {
+            $this->addElement(
+                'select',
+                'grafana_graphType',
+                array(
+                    'label' => 'Graphite graph type',
+                    'value' => 'auto',
+                    'multiOptions' => array(
+                        'auto' => $this->translate('Automatic selection (host/services)'),
+                        'host' => $this->translate('Force branch host'),
+                        'services' => $this->translate('Force branch services'),
+                    ),
+                'description' => $this->translate('Determine the branch to be chosen in the graphite backend.'),
+                'class' => 'autosubmit',
+                )
+            );
+        }
         $this->addElement(
             'select',
             'grafana_accessmode',

--- a/application/forms/Config/GeneralConfigForm.php
+++ b/application/forms/Config/GeneralConfigForm.php
@@ -385,7 +385,7 @@ class GeneralConfigForm extends ConfigForm
             array(
                 'value'=> false,
                 'label' => $this->translate('Show debug'),
-                'description' => $this->translate('Show debuging information.'),
+                'description' => $this->translate('Show debug information.'),
             )
         );
     }

--- a/application/forms/Graph/GraphForm.php
+++ b/application/forms/Graph/GraphForm.php
@@ -114,19 +114,19 @@ class GraphForm extends ConfigForm
         );
         $this->addElement(
             'number',
-            'height',
+            'width',
             array(
-                'label'         => $this->translate('Graph height'),
-                'description'   => $this->translate('The graph height in pixel.'),
+                'label'         => $this->translate('Graph width'),
+                'description'   => $this->translate('The graph width in pixel.'),
                 'required'      => false
             )
         );
         $this->addElement(
             'number',
-            'width',
+            'height',
             array(
-                'label'         => $this->translate('Graph width'),
-                'description'   => $this->translate('The graph width in pixel.'),
+                'label'         => $this->translate('Graph height'),
+                'description'   => $this->translate('The graph height in pixel.'),
                 'required'      => false
             )
         );

--- a/application/forms/Graph/GraphForm.php
+++ b/application/forms/Graph/GraphForm.php
@@ -57,8 +57,7 @@ class GraphForm extends ConfigForm
             )
         );
 
-        if($this->grafanaVersion == "1")
-        {
+        if($this->grafanaVersion == "1") {
             $this->addElement(
                 'text',
                 'dashboarduid',
@@ -189,7 +188,7 @@ class GraphForm extends ConfigForm
         $values = array(
             'dashboard'   => $this->getElement('dashboard')->getValue(),
             'panelId'     => $this->getElement('panelId')->getValue(),
-            'orgId'     => $this->getElement('orgId')->getValue(),
+            'orgId'       => $this->getElement('orgId')->getValue(),
             'customVars'  => $this->getElement('customVars')->getValue(),
             'timerange'   => $this->getElement('timerange')->getValue(),
             'height'      => $this->getElement('height')->getValue(),
@@ -197,17 +196,13 @@ class GraphForm extends ConfigForm
             'repeatable'  => $this->getElement('repeatable')->getValue(),
             'nmetrics'    => $this->getElement('nmetrics')->getValue()
         );
-        if($this->grafanaVersion == "1")
-        {
+        if($this->grafanaVersion == "1") {
             $values['dashboarduid'] = $this->getElement('dashboarduid')->getValue();
         }
-
-
-	    if (empty($values['timerange']))
-	    {
+        if (empty($values['timerange'])) {
             $values['timerange'] = null;
         }
-	    if (empty($values['customVars'])) {
+        if (empty($values['customVars'])) {
             $values['customVars'] = null;
         }
         if (empty($values['height'])) {

--- a/application/forms/Graph/GraphForm.php
+++ b/application/forms/Graph/GraphForm.php
@@ -153,7 +153,7 @@ class GraphForm extends ConfigForm
                 'required'      => false
             )
         );
-}
+    }
 
     /**
      * {@inheritdoc}

--- a/dashboards/graphite/icinga2-default.json
+++ b/dashboards/graphite/icinga2-default.json
@@ -1,41 +1,10 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_GRAPHITE",
-      "label": "Graphite",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "graphite",
-      "pluginName": "Graphite"
-    },
-    {
-      "name": "VAR_HOSTNAME",
-      "type": "constant",
-      "label": "hostname",
-      "value": "null",
-      "description": ""
-    },
-    {
-      "name": "VAR_SERVICE",
-      "type": "constant",
-      "label": "service",
-      "value": "null",
-      "description": ""
-    },
-    {
-      "name": "VAR_COMMAND",
-      "type": "constant",
-      "label": "command",
-      "value": "null",
-      "description": ""
-    }
-  ],
   "__requires": [
     {
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "4.6.3"
+      "version": "6.6.1"
     },
     {
       "type": "panel",
@@ -67,130 +36,534 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "hideControls": false,
   "id": null,
+  "iteration": 1582041090736,
   "links": [],
-  "rows": [
+  "panels": [
     {
-      "collapse": false,
-      "height": 250,
-      "panels": [
+      "collapsed": false,
+      "datasource": "${DS_ICINGA2-GRAPHITE}",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Host Panels",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_ICINGA2-GRAPHITE}",
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_GRAPHITE}",
-          "fill": 1,
-          "id": 1,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "hideZero": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "span": 12,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
+          "dsType": "influxdb",
+          "groupBy": [
             {
-              "dsType": "influxdb",
-              "groupBy": [
-                {
-                  "params": [
-                    "$__interval"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
+              "params": [
+                "$__interval"
               ],
-              "orderByTime": "ASC",
-              "policy": "default",
-              "refId": "A",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "value"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "mean"
-                  }
-                ]
-              ],
-              "tags": [],
-              "target": "aliasByNode(icinga2.$hostname.*.$service.$command.perfdata.*.value, 6)"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "$service",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
+              "type": "time"
             },
             {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
+              "params": [
+                "null"
+              ],
+              "type": "fill"
             }
-          ]
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [],
+          "target": "icinga2.$hostname.$type.$service.perfdata.rta.value",
+          "textEditor": false
         }
       ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "Dashboard Row",
-      "titleSize": "h6"
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "$hostname - hostalive4 rta",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_ICINGA2-GRAPHITE}",
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [],
+          "target": "icinga2.$hostname.$type.$service.perfdata.pl.value",
+          "textEditor": false
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "$hostname - hostalive4 pl",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": "",
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_ICINGA2-GRAPHITE}",
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 1,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [],
+          "target": "icinga2.$hostname.$type.$service.perfdata.*.*",
+          "textEditor": false
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "$hostname - $service",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": "${DS_ICINGA2-GRAPHITE}",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 8,
+      "panels": [],
+      "title": "Services Panels",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_ICINGA2-GRAPHITE}",
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [],
+          "target": "icinga2.$hostname.$type.$service.$command.perfdata.*.value",
+          "textEditor": false
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "$hostname - $service",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
-  "schemaVersion": 14,
+  "refresh": false,
+  "schemaVersion": 22,
   "style": "dark",
   "tags": [
     "icinga2",
@@ -213,6 +586,25 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
+        "skipUrlSync": false,
+        "type": "constant"
+      },
+      {
+        "current": {
+          "value": "${VAR_TYPE}",
+          "text": "${VAR_TYPE}"
+        },
+        "hide": 2,
+        "label": null,
+        "name": "type",
+        "options": [
+          {
+            "value": "${VAR_TYPE}",
+            "text": "${VAR_TYPE}"
+          }
+        ],
+        "query": "${VAR_TYPE}",
+        "skipUrlSync": false,
         "type": "constant"
       },
       {
@@ -230,6 +622,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
+        "skipUrlSync": false,
         "type": "constant"
       },
       {
@@ -247,6 +640,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
+        "skipUrlSync": false,
         "type": "constant"
       }
     ]
@@ -282,5 +676,6 @@
   },
   "timezone": "",
   "title": "icinga2-default",
-  "version": 1
+  "uid": "zUEccGwWk",
+  "version": 17
 }

--- a/library/Grafana/ProvidedHook/Grapher.php
+++ b/library/Grafana/ProvidedHook/Grapher.php
@@ -129,7 +129,7 @@ class Grapher extends GrapherHook
         $this->custvarconfig = ($this->config->get('custvarconfig', $this->custvarconfig));
 
         /**
-         * Show some debug informations?
+         * Show debug information
          */
         $this->debug = ($this->config->get('debug', $this->debug));
         /**
@@ -221,8 +221,8 @@ class Grapher extends GrapherHook
         return $value;
     }
 
-    //returns false on error, previewHTML is passed as reference
     private function getMyPreviewHtml($serviceName, $hostName, &$previewHtml)
+    // returns false on error, previewHTML is passed as reference
     {
         $imgClass = $this->shadows ? "grafana-img grafana-img-shadows" : "grafana-img";
         if ($this->accessMode == "proxy") {
@@ -304,7 +304,7 @@ class Grapher extends GrapherHook
             if ($res === false) {
                 $previewHtml .= "<b>Cannot fetch graph with curl:</b> '" . curl_error($curl_handle) . "'.";
 
-                //provide a hint for 'Failed to connect to ...: Permission denied'
+                // provide a hint for 'Failed to connect to ...: Permission denied'
                 if (curl_errno($curl_handle) == 7) {
                     $previewHtml .= " Check SELinux/Firewall.";
                 }
@@ -528,7 +528,7 @@ class Grapher extends GrapherHook
                 $this->customVars = str_replace($search, $replace, $this->customVars);
             }
 
-            // urlencodee values
+            // urlencode values
             $customVars = "";
             foreach (preg_split('/\&/', $this->customVars, -1, PREG_SPLIT_NO_EMPTY) as $param) {
                 $arr = explode("=", $param);
@@ -555,20 +555,21 @@ class Grapher extends GrapherHook
         }
 
         foreach (explode(',', $this->panelId) as $panelid) {
-
             $html = "";
             $this->panelId = $panelid;
 
-            //image value will be returned as reference
+            // image value will be returned as reference
             $previewHtml = "";
-            $res = $this->getMyPreviewHtml($serviceName, $hostName, $previewHtml);
+            $res = $this->getMyPreviewHtml($serviceName, $hostName, $previewHtml, $graphType);
 
-            //do not render URLs on error or if disabled
-            if (!$res || $this->enableLink == "no" || !$this->permission->hasPermission('grafana/enablelink')) {
+            // do not render URLs on error or if disabled
+            if (!$res
+                || $this->enableLink == "no"
+                || !$this->permission->hasPermission('grafana/enablelink')) {
                 $html .= $previewHtml;
             } else {
                 if ($this->grafanaVersion == "1") {
-                    $html .= '<a href="%s://%s/d/%s/%s?var-hostname=%s&var-service=%s&var-command=%s%s&from=%s&to=%s&orgId=%s&panelId=%s&fullscreen" target="_blank">%s</a>';
+                    $html .= '<a href="%s://%s/d/%s/%s?var-hostname=%s&var-type=%s&var-service=%s&var-command=%s%s&from=%s&to=%s&orgId=%s&panelId=%s&fullscreen" target="_blank">%s</a>';
 
                     $html = sprintf(
                         $html,

--- a/library/Grafana/ProvidedHook/Grapher.php
+++ b/library/Grafana/ProvidedHook/Grapher.php
@@ -681,34 +681,70 @@ class Grapher extends GrapherHook
 
             $return_html .= "<h2>Performance Graph Debug</h2>";
             $return_html .= "<table class=\"name-value-table\"><tbody>";
-            $return_html .= "<tr><th>Access mode</th><td>" . $this->accessMode . "</td>";
-            $return_html .= "<tr><th>Authentication type</th><td>" . $this->authentication . "</td>";
-            $return_html .= "<tr><th>Protocol</th><td>" . $this->protocol . "</td>";
-            $return_html .= "<tr><th>Grafana Host</th><td>" . $this->grafanaHost . "</td>";
+            $return_html .= "<tr><th>Access mode</th><td>"
+                . $this->accessMode . "</td>";
+            $return_html .= "<tr><th>Authentication type</th><td>"
+                . $this->authentication . "</td>";
+            $return_html .= "<tr><th>Protocol</th><td>"
+                . $this->protocol . "</td>";
+            $return_html .= "<tr><th>Grafana Host</th><td>"
+                . $this->grafanaHost . "</td>";
             if ($this->grafanaVersion == "1") {
-                $return_html .= "<tr><th>Dashboard UID</th><td>" . $this->dashboarduid . "</td>";
+                $return_html .= "<tr><th>Dashboard UID</th><td>"
+                    . $this->dashboarduid . "</td>";
             } else {
-                $return_html .= "<tr><th>Dashboard Store</th><td>" . $this->defaultDashboardStore . "</td>";
+                $return_html .= "<tr><th>Dashboard Store</th><td>"
+                    . $this->defaultDashboardStore . "</td>";
             }
-            $return_html .= "<tr><th>Dashboard Name</th><td>" . $this->dashboard . "</td>";
-            $return_html .= "<tr><th>Panel ID</th><td>" . $this->panelId . "</td>";
-            $return_html .= "<tr><th>Organization ID</th><td>" . $this->orgId . "</td>";
-            $return_html .= "<tr><th>Theme</th><td>" . $this->grafanaTheme . "</td>";
-            $return_html .= "<tr><th>Timerange</th><td>" . $this->timerange . "</td>";
-            $return_html .= "<tr><th>Timerangeto</th><td>" . $this->timerangeto . "</td>";
-            $return_html .= "<tr><th>Height</th><td>" . $this->height . "</td>";
-            $return_html .= "<tr><th>Width</th><td>" . $this->width . "</td>";
-            $return_html .= "<tr><th>Custom Variables</th><td>" . $this->customVars . "</td>";
-            $return_html .= "<tr><th>Graph URL</th><td>" . $usedUrl . "</td>";
-            $return_html .= "<tr><th>Disable graph custom variable</th><td>" . $this->custvardisable . "</td>";
-            $return_html .= "<tr><th>Graph config custom variable</th><td>" . $this->custvarconfig . "</td>";
+            $return_html .= "<tr><th>Dashboard Name</th><td>"
+                . $this->dashboard . "</td>";
+            $return_html .= "<tr><th>Organization ID</th><td>"
+                . $this->orgId . "</td>";
+            $return_html .= "<tr><th>Panel ID from GraphConfig</th><td>"
+                . $this->getGraphConfigOption(
+                    $serviceName,
+                    'panelId',
+                    $this->defaultDashboardPanelId)
+                . "</td>";
+            $return_html .= "<tr><th>Last Panel ID</th><td>"
+                . $this->panelId . "</td>";
+            $return_html .= "<tr><th>Number of metrics</th><td>"
+                . substr_count($object->perfdata, '=') . "</td>";
+            $return_html .= "<tr><th>Number of metrics per panel</th><td>"
+                . $this->numberMetrics . "</td>";
+            $return_html .= "<tr><th>Theme</th><td>"
+                . $this->grafanaTheme . "</td>";
+            $return_html .= "<tr><th>Timerange</th><td>"
+                . $this->timerange . "</td>";
+            $return_html .= "<tr><th>Timerangeto</th><td>"
+                . $this->timerangeto . "</td>";
+            $return_html .= "<tr><th>Graph Type</th><td>"
+                . $this->graphType . "</td>";
+            $return_html .= "<tr><th>Object Perfdata</th><td>"
+                . $object->perfdata . "</td>";
+            $return_html .= "<tr><th>Width</th><td>"
+                . $this->width . "</td>";
+            $return_html .= "<tr><th>Height</th><td>"
+                . $this->height . "</td>";
+            $return_html .= "<tr><th>Custom Variables</th><td>"
+                . $this->customVars . "</td>";
+            $return_html .= "<tr><th>Graph URL</th><td>"
+                . $usedUrl . "</td>";
+            $return_html .= "<tr><th>Disable graph custom variable</th><td>"
+                . $this->custvardisable . "</td>";
+            $return_html .= "<tr><th>Graph config custom variable</th><td>"
+                . $this->custvarconfig . "</td>";
             if (isset($object->customvars[$this->custvarconfig])) {
-                $return_html .= "<tr><th>" . $this->custvarconfig . "</th><td>" . $object->customvars[$this->custvarconfig] . "</td>";
+                $return_html .= "<tr><th>" . $this->custvarconfig . "</th><td>"
+                    . $object->customvars[$this->custvarconfig] . "</td>";
             }
-            $return_html .= "<tr><th>Shadows</th><td>" . (($this->shadows) ? 'Yes' : 'No') . "</td>";
+            $return_html .= "<tr><th>Shadows</th><td>"
+                . (($this->shadows) ? 'Yes' : 'No') . "</td>";
             if ($this->accessMode == "proxy") {
-                $return_html .= "<tr><th>SSL Verify Peer</th><td>" . (($this->SSLVerifyPeer) ? 'Yes' : 'No') . "</td>";
-                $return_html .= "<tr><th>SSL Verify Host</th><td>" . (($this->SSLVerifyHost) ? 'Yes' : 'No') . "</td>";
+                $return_html .= "<tr><th>SSL Verify Peer</th><td>"
+                . (($this->SSLVerifyPeer) ? 'Yes' : 'No') . "</td>";
+                $return_html .= "<tr><th>SSL Verify Host</th><td>"
+                . (($this->SSLVerifyHost) ? 'Yes' : 'No') . "</td>";
             }
             $return_html .= " </tbody></table>";
 


### PR DESCRIPTION
Icinga2-graphite writer distinguishes between metrics
that are attached to a hosts and those that are attached to services.
This patch-set makes it easier to switch between graphite and grafana modules,
by making the graphite path ($hostname -> $type (host|services)) -> …) configurable
in icingaweb2-module-grafana. I did my best to not break existing installations,
all changes should be limited to the graphite datasource.
Defaults in icinga2-graphite writer should be sufficient to satisfy both modules.

Furthermore: clean up some code.

Please pull it in soon. Thanks.