### PR TITLE
Don't use deprecated jQuery features

### DIFF
--- a/library/Grafana/Helpers/Timeranges.php
+++ b/library/Grafana/Helpers/Timeranges.php
@@ -135,7 +135,7 @@ class Timeranges
         $menu .= '</tr></table>';
         $menu .= '<script type="text/javascript">
 $( document ).ready(function() {
-    $("a.grafana-module-tr-apply").click(function() {
+    $("a.grafana-module-tr-apply").on("click", function() {
         var old_href = $(this).attr("href");
         var tr_from = $("input[name=tr-from]").val();
         var tr_to = $("input[name=tr-to]").val();


### PR DESCRIPTION
Icinga Web 2.7 upgraded the shipped jQuery version from 2.x to 3.x. With this some deprecated features are not available anymore. We are currently shipping jQuery-migrate since then as well, which acts as a temporary compatibility layer and ensures modules using these features will still work. Though, jQuery-migrate will be removed with Icinga Web 2.9 (https://github.com/Icinga/icingaweb2/issues/3869) and any code still making use of those features will break.

This changes such a usage so that it will still work. I didn't have a more detailed look if you're making use of more such features. Please do so on your own. (Or anyone else) Might come in handy: https://jquery.com/upgrade-guide/3.0/