### PR TITLE
Add new filters to apply dashboards

### DIFF
--- a/application/forms/Graph/GraphForm.php
+++ b/application/forms/Graph/GraphForm.php
@@ -49,6 +49,31 @@ class GraphForm extends ConfigForm
 
         $this->addElement(
             'text',
+            'serviceFilter',
+            array(
+                'description'   => $this->translate(
+                    'Use the dashboard if the filter matches the service name.  (String or RegEx) '
+                    . '(Examples: "disk.*" or "disk /var/(log|lib).*")'
+                ),
+                'label'         => $this->translate('Service filter'),
+                'required'      => false
+            )
+        );
+
+        $this->addElement(
+            'text',
+            'commandFilter',
+            array(
+                'description'   => $this->translate(
+                    'Use the dashboard if the filter matches the check_command. (String or RegEx)'
+                ),
+                'label'         => $this->translate('Command filter'),
+                'required'      => false
+            )
+        );
+
+        $this->addElement(
+            'text',
             'dashboard',
             array(
                 'placeholder'   => 'DashboardName',
@@ -185,6 +210,8 @@ class GraphForm extends ConfigForm
     {
         $name = $this->getElement('name')->getValue();
         $values = array(
+            'serviceFilter' => $this->getElement('serviceFilter')->getValue(),
+            'commandFilter' => $this->getElement('commandFilter')->getValue(),
             'dashboard'   => $this->getElement('dashboard')->getValue(),
             'panelId'     => $this->getElement('panelId')->getValue(),
             'orgId'     => $this->getElement('orgId')->getValue(),
@@ -197,6 +224,12 @@ class GraphForm extends ConfigForm
             'dashboarduid' => $this->getElement('dashboarduid')->getValue()
         );
 
+        if (empty($values['serviceFilter'])) {
+            $values['serviceFilter'] = null;
+        }
+        if (empty($values['commandFilter'])) {
+            $values['commandFilter'] = null;
+        }
 	    if (empty($values['timerange']))
 	    {
             $values['timerange'] = null;

--- a/application/views/scripts/graph/index.phtml
+++ b/application/views/scripts/graph/index.phtml
@@ -20,6 +20,8 @@
         <thead>
             <tr>
                 <th><?= $this->translate('Name') ?></th>
+                <th><?= $this->translate('Service filter') ?></th>
+                <th><?= $this->translate('Command filter') ?></th>
                 <th><?= $this->translate('Dashboard') ?></th>
                 <th><?= $this->translate('Dashboard UID') ?></th>
                 <th><?= $this->translate('PanelID') ?></th>
@@ -43,6 +45,8 @@
                         array('title' => sprintf($this->translate('Update Grafana graph %s'), $name))
                     ) ?>
                 </td>
+                <td><?= $this->escape($graph->serviceFilter) ?></td>
+                <td><?= $this->escape($graph->commandFilter) ?></td>
                 <td><?= $this->escape($graph->dashboard) ?></td>
                 <td><?= $this->escape($graph->dashboarduid) ?></td>
                 <td><?= $this->escape($graph->panelId) ?></td>


### PR DESCRIPTION
This adds two new values to apply a dashboard. The first filter allows the use of the service name and the second allows to filter by the command name. Both filters can be used together and if both are given both have to match to apply a dashboard.

It is also possible to use a regex because both filters use ```preg_match()```.

If you like you can merge #272 first. I will do a rebase and fix it if there are any merge conflicts.