### PR TITLE
Found Difference in provided dashboards on import

### DIFF
--- a/dashboards/influxdb/auto-repeat-disk.json
+++ b/dashboards/influxdb/auto-repeat-disk.json
@@ -12,14 +12,14 @@
       "name": "VAR_HOSTNAME",
       "type": "constant",
       "label": "hostname",
-      "value": "",
+      "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
       "type": "constant",
       "label": "service",
-      "value": "",
+      "value": "null",
       "description": ""
     }
   ],


### PR DESCRIPTION
On the initial import, I found that content is manually needed for this dashboard in order for Grafana to accept the import. For `icinga2-default.json`, "null" is specified and one is able to import the dashboard without any immediate changes. Requesting to update the first dashboard file to match the other for consistency.