### PR TITLE
Add link when using iframes to have iframes without using the grafana-renderer and still have links to Grafana

### DIFF
--- a/application/forms/Config/GeneralConfigForm.php
+++ b/application/forms/Config/GeneralConfigForm.php
@@ -280,6 +280,15 @@ class GeneralConfigForm extends ConfigForm
                     'description' => $this->translate('The default graph width in pixels.')
                 )
             );
+        } 
+ 
+        if (isset($formData['grafana_accessmode'])) {
+            if ($formData['grafana_accessmode'] === 'indirectproxy') {
+                $desc = 'Image is a link to the dashboard on the Grafana server.';
+            }
+            else {
+                $desc = 'Above image is a link to the dashboard on the Grafana server.';
+            }
             $this->addElement(
                 'select',
                 'grafana_enableLink',
@@ -290,12 +299,12 @@ class GeneralConfigForm extends ConfigForm
                         'yes' => $this->translate('Yes'),
                         'no' => $this->translate('No'),
                     ),
-                    'description' => $this->translate('Image is an link to the dashboard on the Grafana server.'),
+                    'description' => $this->translate($desc),
                     'class' => 'autosubmit'
                 )
             );
         }
-        if (isset($formData['grafana_enableLink']) && ( $formData['grafana_enableLink'] === 'yes') && ( $formData['grafana_accessmode'] != 'iframe' )) {
+        if (isset($formData['grafana_enableLink']) && ( $formData['grafana_enableLink'] === 'yes')) {
             $this->addElement(
                 'select',
                 'grafana_usepublic',
@@ -311,7 +320,7 @@ class GeneralConfigForm extends ConfigForm
                 )
             );
         }
-        if (isset($formData['grafana_usepublic']) && ( $formData['grafana_usepublic'] === 'yes' ) && ( $formData['grafana_accessmode'] != 'iframe' )) {
+        if (isset($formData['grafana_usepublic']) && ( $formData['grafana_usepublic'] === 'yes' )) {
             $this->addElement(
                 'text',
                 'grafana_publichost',

--- a/library/Grafana/ProvidedHook/Grapher.php
+++ b/library/Grafana/ProvidedHook/Grapher.php
@@ -247,7 +247,7 @@ class Grapher extends GrapherHook
             );
         } elseif ($this->accessMode == "iframe") {
             $iframehtml = '<iframe src="%s://%s/d-solo/%s/%s?var-hostname=%s&var-service=%s&var-command=%s%s&panelId=%s&orgId=%s&theme=%s&from=%s&to=%s" alt="%s" height="%d" frameBorder="0" style="width: 100%%;"></iframe>';
-            $previewHtml = sprintf(
+            $framehtml = sprintf(
                 $iframehtml,
                 $this->protocol,
                 $this->grafanaHost,
@@ -265,6 +265,30 @@ class Grapher extends GrapherHook
                 rawurlencode($serviceName),
                 $this->height
             );
+
+            if ($this->enableLink == "no" || !$this->permission->hasPermission('grafana/enablelink')) {
+                $htmllink = "";
+            } else {
+                            $html = '<a href="%s://%s/d/%s/%s?var-hostname=%s&var-service=%s&var-command=%s%s&from=%s&to=%s&orgId=%s&viewPanel=%s" target="_blank">%s</a>';
+    
+                $htmllink = sprintf(
+                    $html,
+                    $this->protocol,
+                    $this->grafanaHost,
+                    $this->dashboarduid,
+                    $this->dashboard,
+                    rawurlencode(($this->dataSource == "graphite" ? Util::graphiteReplace($hostName) : $hostName)),
+                    rawurlencode(($this->dataSource == "graphite" ? Util::graphiteReplace($serviceName) : $serviceName)),
+                    rawurlencode($this->object->check_command),
+                    $this->customVars,
+                    urlencode($this->timerange),
+                    urlencode($this->timerangeto),
+                    $this->orgId,
+                    $this->panelId,
+                    "=> see in Grafana"
+                );
+            }               
+            $previewHtml = "<div>" . $htmllink . $framehtml . "</div>";
         }
         return true;
     }


### PR DESCRIPTION
Hi Carsten
We have the problem, that the grafana-renderer is very slow and uses a lot resources. Is much faster, to use iframes to embed graphs in icingaweb2. Further you then have tooltips in the graphs.
The downside is, that you do no longer have links to grafana to open a dashboard from icingaweb2.
So I extended Grapher.php to add a link above the grafana panels embedded as iframes into icingaweb2. With this, you have much faster rendering of the graphs in the iframes and you still can click on a link '=> see in Grafana' to open the panel in Grafana.

I did the according changes to GeneralConfigForm.php to be able to interactively do the config for the grafana-module too.