### PR TITLE
fix deprecation for empty parameter for strpos method

### DIFF
--- a/application/controllers/IcingadbimgController.php
+++ b/application/controllers/IcingadbimgController.php
@@ -66,7 +66,7 @@ class IcingadbimgController extends IcingadbGrafanaController
         if ($this->hasParam('timerangeto')) {
             $this->timerangeto = urldecode($this->getParam('timerangeto'));
         } else {
-            $this->timerangeto = strpos($this->timerange, '/') ? 'now-' . $this->timerange : "now";
+            $this->timerangeto = strpos($this->timerange ?? '', '/') ? 'now-' . $this->timerange ?? '' : "now";
         }
         $this->cacheTime = $this->hasParam('cachetime') ? $this->getParam('cachetime') : 300;
 

--- a/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
+++ b/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
@@ -236,7 +236,7 @@ trait IcingaDbGrapher
             $this->timerange = Url::fromRequest()->hasParam('timerange') ?
                 'now-' . urldecode(Url::fromRequest()->getParam('timerange')) :
                 'now-' . $this->getGraphConfigOption($serviceName, 'timerange', $this->timerange);
-            $this->timerangeto = strpos($this->timerange, '/') ? $this->timerange : $this->timerangeto;
+            $this->timerangeto = strpos($this->timerange ?? '', '/') ? $this->timerange : $this->timerangeto;
         }
 
         $this->height = $this->getGraphConfigOption($serviceName, 'height', $this->height);


### PR DESCRIPTION
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /usr/share/icingaweb2/modules/grafana/application/controllers/IcingadbimgController.php on line 68

This message appears when the strpos funtion is called with an empty parameter.
This is deprecated in 8.1 and probably will be removed in PHP 9.
These changes prevent the value from being NULL.